### PR TITLE
New wrapper syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ yarn add read-vietnamese-number
 
 ## Usage
 
-Cách sử dụng gồm 4 bước:
+Cách sử dụng gồm 3 bước:
 
-- Tạo object cấu hình và điều chỉnh phù hợp
-- Kiểm tra định dạng chuỗi số hợp lệ
-- Phân tích chuỗi số
-- Đọc số đã phân tích
+- Tạo cấu hình đọc số và điều chỉnh phù hợp
+- Đọc chuỗi số với cấu hình đã tạo
+- Xử lý lỗi phát sinh
 
 ### Code example
 
@@ -37,22 +36,20 @@ import {
 	InvalidNumberError,
 	UnitNotEnoughError,
 	ReadingConfig,
-	validateNumber,
-	parseNumberData,
-	readNumber,
+	doReadNumber,
 } from 'read-vietnamese-number'
 
-// Step 1
+// Config reading options
 const config = new ReadingConfig()
 config.unit = ['đồng']
 
 try {
-	const number = '12345.6789'
-	const validatedNumber = validateNumber(number) // Step 2
-	const numberData = parseNumberData(config, validatedNumber) // Step 3
-	const result = readNumber(config, numberData) // Step 4
+	// Start reading
+	const number = '-12345.6789'
+	const result = doReadNumber(config, number)
 	console.log(result)
 } catch (err) {
+	// Handle errors
 	if (err instanceof InvalidFormatError) {
 		console.error('Định dạng input không hợp lệ')
 	} else if (err instanceof InvalidNumberError) {
@@ -90,12 +87,9 @@ const rvn = require('read-vietnamese-number')
 
 // For simplicity, this code doesn't handle errors
 const config = new rvn.ReadingConfig()
-const number = '12345.6789'
-const validatedNumber = rvn.validateNumber(number)
-const numberData = rvn.parseNumberData(config, validatedNumber)
-const output = rvn.readNumber(config, numberData)
-
-console.log(output)
+const number = '-12345.6789'
+const result = rvn.doReadNumber(config, number)
+console.log(result)
 ```
 
 ## Contributing

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -6,9 +6,7 @@ import {
 	InvalidNumberError,
 	UnitNotEnoughError,
 	ReadingConfig,
-	validateNumber,
-	parseNumberData,
-	readNumber,
+	doReadNumber,
 } from './index' // or 'read-vietnamese-number'
 
 async function input(
@@ -22,13 +20,9 @@ async function input(
 
 function read(config: ReadingConfig, number: string): void {
 	try {
-		// Parse the number and start reading
-		const validatedNumber = validateNumber(number)
-		const numberData = parseNumberData(config, validatedNumber)
-		const result = readNumber(config, numberData)
+		const result = doReadNumber(config, number)
 		console.log(result)
 	} catch (err) {
-		// Handle errors
 		if (err instanceof InvalidFormatError) {
 			console.error('Định dạng input không hợp lệ')
 		} else if (err instanceof InvalidNumberError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
 	ReadingConfig,
 } from './type'
 import { validateNumber } from './util'
-import { parseNumberData, readNumber } from './reader'
+import { parseNumberData, readNumber, doReadNumber } from './reader'
 
 export {
 	RvnError,
@@ -19,4 +19,5 @@ export {
 	validateNumber,
 	parseNumberData,
 	readNumber,
+	doReadNumber,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,21 +3,15 @@ import {
 	InvalidFormatError,
 	InvalidNumberError,
 	UnitNotEnoughError,
-	NumberData,
 	ReadingConfig,
 } from './type'
-import { validateNumber } from './util'
-import { parseNumberData, readNumber, doReadNumber } from './reader'
+import { doReadNumber } from './reader'
 
 export {
 	RvnError,
 	InvalidFormatError,
 	InvalidNumberError,
 	UnitNotEnoughError,
-	NumberData,
 	ReadingConfig,
-	validateNumber,
-	parseNumberData,
-	readNumber,
 	doReadNumber,
 }

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -8,7 +8,7 @@ import {
 } from './type'
 import { trimLeft, trimRight, splitToDigits, validateNumber } from './util'
 
-function readLastTwoDigits(
+export function readLastTwoDigits(
 	config: ReadingConfig,
 	b: number,
 	c: number
@@ -45,7 +45,7 @@ function readLastTwoDigits(
 	return output
 }
 
-function readThreeDigits(
+export function readThreeDigits(
 	config: ReadingConfig,
 	a: number,
 	b: number,
@@ -67,7 +67,7 @@ function readThreeDigits(
 	return output
 }
 
-function removeThousandsSeparators(
+export function removeThousandsSeparators(
 	config: ReadingConfig,
 	number: string
 ): string {
@@ -75,13 +75,16 @@ function removeThousandsSeparators(
 	return number.replace(regex, '')
 }
 
-function trimRedundantZeros(config: ReadingConfig, number: string): string {
+export function trimRedundantZeros(
+	config: ReadingConfig,
+	number: string
+): string {
 	return number.includes(config.pointSign)
 		? trimLeft(trimRight(number, config.filledDigit), config.filledDigit)
 		: trimLeft(number, config.filledDigit)
 }
 
-function addLeadingZerosToFitPeriod(
+export function addLeadingZerosToFitPeriod(
 	config: ReadingConfig,
 	number: string
 ): string {
@@ -90,7 +93,10 @@ function addLeadingZerosToFitPeriod(
 	return number.padStart(newLength, config.filledDigit)
 }
 
-function zipIntegralPeriods(config: ReadingConfig, digits: number[]): Period[] {
+export function zipIntegralPeriods(
+	config: ReadingConfig,
+	digits: number[]
+): Period[] {
 	const output: Period[] = []
 	const periodCount = Math.ceil(digits.length / config.periodSize)
 	for (let i = 0; i < periodCount; i++) {
@@ -103,7 +109,10 @@ function zipIntegralPeriods(config: ReadingConfig, digits: number[]): Period[] {
 	return output
 }
 
-function parseNumberData(config: ReadingConfig, number: string): NumberData {
+export function parseNumberData(
+	config: ReadingConfig,
+	number: string
+): NumberData {
 	let numberString = removeThousandsSeparators(config, number)
 
 	const isNegative = numberString[0] === config.negativeSign
@@ -133,7 +142,10 @@ function parseNumberData(config: ReadingConfig, number: string): NumberData {
 	return { isNegative, integralPart, fractionalPart }
 }
 
-function readIntegralPart(config: ReadingConfig, periods: Period[]): string[] {
+export function readIntegralPart(
+	config: ReadingConfig,
+	periods: Period[]
+): string[] {
 	const output: string[] = []
 	const isSinglePeriod = periods.length === 1
 	for (const [index, period] of periods.entries()) {
@@ -149,7 +161,10 @@ function readIntegralPart(config: ReadingConfig, periods: Period[]): string[] {
 	return output
 }
 
-function readFractionalPart(config: ReadingConfig, digits: number[]): string[] {
+export function readFractionalPart(
+	config: ReadingConfig,
+	digits: number[]
+): string[] {
 	const output: string[] = []
 	switch (digits.length) {
 		case 2: {
@@ -172,7 +187,10 @@ function readFractionalPart(config: ReadingConfig, digits: number[]): string[] {
 	return output
 }
 
-function readNumber(config: ReadingConfig, numberData: NumberData): string {
+export function readNumber(
+	config: ReadingConfig,
+	numberData: NumberData
+): string {
 	const output: string[] = []
 	output.push(...readIntegralPart(config, numberData.integralPart))
 	if (numberData.fractionalPart.length !== 0) {
@@ -188,22 +206,8 @@ function readNumber(config: ReadingConfig, numberData: NumberData): string {
 	return output.join(config.separator)
 }
 
-function doReadNumber(config: ReadingConfig, number: InputNumber) {
+export function doReadNumber(config: ReadingConfig, number: InputNumber) {
 	const validatedNumber = validateNumber(number)
 	const numberData = parseNumberData(config, validatedNumber)
 	return readNumber(config, numberData)
-}
-
-export {
-	readLastTwoDigits,
-	readThreeDigits,
-	removeThousandsSeparators,
-	trimRedundantZeros,
-	addLeadingZerosToFitPeriod,
-	zipIntegralPeriods,
-	parseNumberData,
-	readIntegralPart,
-	readFractionalPart,
-	readNumber,
-	doReadNumber,
 }

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -1,11 +1,12 @@
 import {
 	Period,
+	InputNumber,
 	InvalidNumberError,
 	UnitNotEnoughError,
 	NumberData,
 	ReadingConfig,
 } from './type'
-import { splitToDigits, trimLeft, trimRight } from './util'
+import { trimLeft, trimRight, splitToDigits, validateNumber } from './util'
 
 function readLastTwoDigits(
 	config: ReadingConfig,
@@ -187,6 +188,12 @@ function readNumber(config: ReadingConfig, numberData: NumberData): string {
 	return output.join(config.separator)
 }
 
+function doReadNumber(config: ReadingConfig, number: InputNumber) {
+	const validatedNumber = validateNumber(number)
+	const numberData = parseNumberData(config, validatedNumber)
+	return readNumber(config, numberData)
+}
+
 export {
 	readLastTwoDigits,
 	readThreeDigits,
@@ -198,4 +205,5 @@ export {
 	readIntegralPart,
 	readFractionalPart,
 	readNumber,
+	doReadNumber,
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,5 @@
 type Period = [number, number, number]
+type InputNumber = string | bigint | number | null | undefined
 
 class RvnError extends Error {}
 class InvalidFormatError extends RvnError {}
@@ -56,6 +57,7 @@ class ReadingConfig {
 
 export {
 	Period,
+	InputNumber,
 	RvnError,
 	InvalidFormatError,
 	InvalidNumberError,

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,18 +1,18 @@
-type Period = [number, number, number]
-type InputNumber = string | bigint | number | null | undefined
+export type Period = [number, number, number]
+export type InputNumber = string | bigint | number | null | undefined
 
-class RvnError extends Error {}
-class InvalidFormatError extends RvnError {}
-class InvalidNumberError extends RvnError {}
-class UnitNotEnoughError extends RvnError {}
+export class RvnError extends Error {}
+export class InvalidFormatError extends RvnError {}
+export class InvalidNumberError extends RvnError {}
+export class UnitNotEnoughError extends RvnError {}
 
-interface NumberData {
+export interface NumberData {
 	isNegative: boolean
 	integralPart: Period[]
 	fractionalPart: number[]
 }
 
-class ReadingConfig {
+export class ReadingConfig {
 	public separator = ' '
 	public unit = ['đơn', 'vị']
 	public negativeSign = '-'
@@ -53,15 +53,4 @@ class ReadingConfig {
 	public fourToneText = 'tư'
 	public fiveToneText = 'lăm'
 	public tenToneText = 'mươi'
-}
-
-export {
-	Period,
-	InputNumber,
-	RvnError,
-	InvalidFormatError,
-	InvalidNumberError,
-	UnitNotEnoughError,
-	NumberData,
-	ReadingConfig,
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { InputNumber, InvalidFormatError } from './type'
 
-function trimLeft(str: string, char: string): string {
+export function trimLeft(str: string, char: string): string {
 	if (str === '') {
 		return ''
 	}
@@ -11,7 +11,7 @@ function trimLeft(str: string, char: string): string {
 	return str.substring(pos)
 }
 
-function trimRight(str: string, char: string): string {
+export function trimRight(str: string, char: string): string {
 	if (str === '') {
 		return ''
 	}
@@ -22,11 +22,11 @@ function trimRight(str: string, char: string): string {
 	return str.substring(0, lastPos + 1)
 }
 
-function splitToDigits(str: string): number[] {
+export function splitToDigits(str: string): number[] {
 	return str.split('').map((digit) => parseInt(digit))
 }
 
-function validateNumber(value: InputNumber): string {
+export function validateNumber(value: InputNumber): string {
 	// String type in TS maybe number at runtime
 	switch (typeof value) {
 		case 'string': {
@@ -59,5 +59,3 @@ function validateNumber(value: InputNumber): string {
 		}
 	}
 }
-
-export { trimLeft, trimRight, splitToDigits, validateNumber }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { InvalidFormatError } from './type'
+import { InputNumber, InvalidFormatError } from './type'
 
 function trimLeft(str: string, char: string): string {
 	if (str === '') {
@@ -26,9 +26,7 @@ function splitToDigits(str: string): number[] {
 	return str.split('').map((digit) => parseInt(digit))
 }
 
-function validateNumber(
-	value: string | bigint | number | null | undefined
-): string {
+function validateNumber(value: InputNumber): string {
 	// String type in TS maybe number at runtime
 	switch (typeof value) {
 		case 'string': {

--- a/test/reader.test.ts
+++ b/test/reader.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect } from '@jest/globals'
 
 import {
-	InputNumber,
 	InvalidFormatError,
 	InvalidNumberError,
 	UnitNotEnoughError,
 	NumberData,
 	ReadingConfig,
 } from '../src/type'
-import { validateNumber } from '../src/util'
 import {
 	readLastTwoDigits,
 	readThreeDigits,
@@ -19,7 +17,7 @@ import {
 	parseNumberData,
 	readIntegralPart,
 	readFractionalPart,
-	readNumber,
+	doReadNumber,
 } from '../src/reader'
 
 describe('Read the last two digits function', () => {
@@ -291,79 +289,84 @@ describe('Read fractional part function', () => {
 	})
 })
 
-describe('Read full string number', () => {
-	const func = (config: ReadingConfig, number: InputNumber) => {
-		const validatedNumber = validateNumber(number)
-		const numberData = parseNumberData(config, validatedNumber)
-		return readNumber(config, numberData)
-	}
+describe('Do read number function', () => {
 	const config = new ReadingConfig()
 	config.unit = []
 
 	it('Should throw InvalidFormatError', () => {
-		expect(() => func(config, 0)).toThrowError(InvalidFormatError)
-		expect(() => func(config, -12345)).toThrowError(InvalidFormatError)
-		expect(() => func(config, 0.000000000012345)).toThrowError(
+		expect(() => doReadNumber(config, 0)).toThrowError(InvalidFormatError)
+		expect(() => doReadNumber(config, -12345)).toThrowError(InvalidFormatError)
+		expect(() => doReadNumber(config, 0.000000000012345)).toThrowError(
 			InvalidFormatError
 		)
 		// eslint-disable-next-line @typescript-eslint/no-loss-of-precision
-		expect(() => func(config, -1234567890123456789012)).toThrowError(
+		expect(() => doReadNumber(config, -1234567890123456789012)).toThrowError(
 			InvalidFormatError
 		)
 	})
 
 	it('Should throw InvalidNumberError', () => {
-		expect(() => func(config, '1..23')).toThrowError(InvalidNumberError)
-		expect(() => func(config, '--1.23')).toThrowError(InvalidNumberError)
-		expect(() => func(config, '12_3')).toThrowError(InvalidNumberError)
-		expect(() => func(config, 'abc123')).toThrowError(InvalidNumberError)
+		expect(() => doReadNumber(config, '1..23')).toThrowError(InvalidNumberError)
+		expect(() => doReadNumber(config, '--1.23')).toThrowError(
+			InvalidNumberError
+		)
+		expect(() => doReadNumber(config, '12_3')).toThrowError(InvalidNumberError)
+		expect(() => doReadNumber(config, 'abc123')).toThrowError(
+			InvalidNumberError
+		)
 	})
 
 	it('Should throw UnitNotEnoughError', () => {
-		expect(() => func(config, '1234567890123456789012')).toThrowError(
-			UnitNotEnoughError
-		)
-		expect(() => func(config, '123456789012345678901')).not.toThrowError(
+		expect(() => doReadNumber(config, '1234567890123456789012')).toThrowError(
 			UnitNotEnoughError
 		)
 		expect(() =>
-			func(config, '123456789012345678901.123456789')
+			doReadNumber(config, '123456789012345678901')
+		).not.toThrowError(UnitNotEnoughError)
+		expect(() =>
+			doReadNumber(config, '123456789012345678901.123456789')
 		).not.toThrowError(UnitNotEnoughError)
 	})
 
 	it('Should return zero', () => {
-		expect(func(config, '')).toBe('không')
-		expect(func(config, '0')).toBe('không')
-		expect(func(config, '000')).toBe('không')
-		expect(func(config, '00.')).toBe('không')
-		expect(func(config, '.00')).toBe('không')
-		expect(func(config, '000.00')).toBe('không')
+		expect(doReadNumber(config, '')).toBe('không')
+		expect(doReadNumber(config, '0')).toBe('không')
+		expect(doReadNumber(config, '000')).toBe('không')
+		expect(doReadNumber(config, '00.')).toBe('không')
+		expect(doReadNumber(config, '.00')).toBe('không')
+		expect(doReadNumber(config, '000.00')).toBe('không')
 	})
 
 	it('Should return integer value', () => {
-		expect(func(config, '02')).toBe('hai')
-		expect(func(config, '15')).toBe('mười lăm')
-		expect(func(config, '4065')).toBe('bốn nghìn không trăm sáu mươi lăm')
-		expect(func(config, '06000')).toBe('sáu nghìn')
-		expect(func(config, '1000024')).toBe('một triệu không trăm hai mươi tư')
-		expect(func(config, '23010000')).toBe(
+		expect(doReadNumber(config, '02')).toBe('hai')
+		expect(doReadNumber(config, '15')).toBe('mười lăm')
+		expect(doReadNumber(config, '4065')).toBe(
+			'bốn nghìn không trăm sáu mươi lăm'
+		)
+		expect(doReadNumber(config, '06000')).toBe('sáu nghìn')
+		expect(doReadNumber(config, '1000024')).toBe(
+			'một triệu không trăm hai mươi tư'
+		)
+		expect(doReadNumber(config, '23010000')).toBe(
 			'hai mươi ba triệu không trăm mười nghìn'
 		)
-		expect(func(config, '2030000305')).toBe(
+		expect(doReadNumber(config, '2030000305')).toBe(
 			'hai tỉ không trăm ba mươi triệu ba trăm lẻ năm'
 		)
-		expect(func(config, '00,123,456')).toBe(
+		expect(doReadNumber(config, '00,123,456')).toBe(
 			'một trăm hai mươi ba nghìn bốn trăm năm mươi sáu'
 		)
 	})
 
 	it('Should return double value', () => {
-		expect(func(config, '304.23')).toBe('ba trăm lẻ bốn chấm hai mươi ba')
-		expect(func(config, '-0003.804')).toBe('âm ba chấm tám trăm lẻ bốn')
-		expect(func(config, '-0.00001')).toBe(
+		expect(doReadNumber(config, '304.23')).toBe(
+			'ba trăm lẻ bốn chấm hai mươi ba'
+		)
+		expect(doReadNumber(config, '-0003.804')).toBe('âm ba chấm tám trăm lẻ bốn')
+		expect(doReadNumber(config, '-0.00001')).toBe(
 			'âm không chấm không không không không một'
 		)
-		expect(func(config, '-123,456.7,89')).toBe(
+		expect(doReadNumber(config, '-123,456.7,89')).toBe(
 			'âm một trăm hai mươi ba nghìn bốn trăm năm mươi sáu chấm bảy trăm tám mươi chín'
 		)
 	})

--- a/test/reader.test.ts
+++ b/test/reader.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@jest/globals'
 
 import {
+	InputNumber,
 	InvalidFormatError,
 	InvalidNumberError,
 	UnitNotEnoughError,
@@ -291,7 +292,7 @@ describe('Read fractional part function', () => {
 })
 
 describe('Read full string number', () => {
-	const func = (config: ReadingConfig, number: string | bigint | number) => {
+	const func = (config: ReadingConfig, number: InputNumber) => {
 		const validatedNumber = validateNumber(number)
 		const numberData = parseNumberData(config, validatedNumber)
 		return readNumber(config, numberData)


### PR DESCRIPTION
Add a new wrapper function to make the library easier to use.

In the previous version, you need to call these 3 functions in order.

```js
const number = '-12345.6789'
const validatedNumber = validateNumber(number)
const numberData = parseNumberData(config, validatedNumber)
const result = readNumber(config, numberData)
console.log(result)
```

And in the current version, only one is needed.

```js
const number = '-12345.6789'
const result = doReadNumber(config, number)
console.log(result)
```